### PR TITLE
chore: Update Next.js image configuration to use remotePatterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,7 +15,13 @@ const nextConfig = {
     return config;
   },
   images: {
-    domains: ["ai3.info"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "ai3.info",
+        pathname: "/**",
+      },
+    ],
   },
   async headers() {
     return [


### PR DESCRIPTION
Replaces deprecated `images.domains` with `remotePatterns` in next.config.mjs for Next.js 14+ compatibility.

- `images.domains` is deprecated in Next.js 14+
- Uses `remotePatterns` with protocol, hostname, and pathname for ai3.info

Made with [Cursor](https://cursor.com)