### PR TITLE
fix: correct typo 'gager' to 'gauger' in package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai3-info",
   "version": "0.1.0",
   "private": true,
-  "description": "A simple space pledged gager to calculate and display the space pledged on the Autonomys Network.",
+  "description": "A simple space pledged gauger to calculate and display the space pledged on the Autonomys Network.",
   "repository": {
     "type": "git",
     "url": "https://github.com/marc-aurele-besner/ai3-info"


### PR DESCRIPTION
Fixes typo in package.json: 'space pledged gager' → 'space pledged gauger'

Made with [Cursor](https://cursor.com)