### PR TITLE
Add link back to home page on error page

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -21,12 +21,20 @@ export default function Error({ error, reset }: ErrorPageProps) {
         <p className="text-lg mb-8 text-center text-gray-300">
           {error.message || "An unexpected error occurred"}
         </p>
-        <button
-          onClick={reset}
-          className="px-6 py-3 border border-[#576EB2] text-[#576EB2] rounded hover:bg-[#576EB2] hover:text-black transition duration-300"
-        >
-          Try again
-        </button>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+          <button
+            onClick={reset}
+            className="px-6 py-3 border border-[#576EB2] text-[#576EB2] rounded hover:bg-[#576EB2] hover:text-black transition duration-300"
+          >
+            Try again
+          </button>
+          <a
+            href="/"
+            className="px-6 py-3 border border-[#576EB2] text-[#576EB2] rounded hover:bg-[#576EB2] hover:text-black transition duration-300"
+          >
+            Go back home
+          </a>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
**Error UX:** The error page now includes a link back to the home page, matching the pattern used on the 404 not-found page.

Users who encounter an error can now easily navigate back to the home page in addition to the existing "Try again" button.

Made with [Cursor](https://cursor.com)