### PR TITLE
Fix README: Add missing CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to AI3 Info
+
+Thank you for your interest in contributing to AI3 Info! This document provides guidelines for contributing to the project.
+
+## Code of Conduct
+
+Be respectful and constructive. We aim to maintain a welcoming environment for everyone.
+
+## How to Contribute
+
+### Reporting Issues
+
+- Use the [Issue Tracker](https://github.com/marc-aurele-besner/ai3-info/issues) to report bugs or suggest features
+- Provide a clear description and steps to reproduce when reporting bugs
+
+### Submitting Pull Requests
+
+1. **Fork** the repository and create a branch from `main`
+2. **Make your changes** following the existing code style
+3. **Test** your changes locally (`yarn dev`, `yarn build`)
+4. **Commit** with clear, descriptive messages
+5. **Push** to your fork and open a Pull Request against `main`
+6. Describe your changes in the PR description
+
+### Development Setup
+
+```bash
+git clone https://github.com/marc-aurele-besner/ai3-info.git
+cd ai3-info
+yarn install
+yarn dev
+```
+
+See the [README](README.md) for full setup instructions including environment variables.


### PR DESCRIPTION
## Summary
The README references CONTRIBUTING.md, which did not exist in the repo. This PR adds a CONTRIBUTING.md file with:
- Code of conduct
- How to report issues
- Pull request process
- Development setup instructions

This resolves the broken link and provides the contribution guidelines promised in the README.

Made with [Cursor](https://cursor.com)